### PR TITLE
Fixed 8 flaky tests in CheckedProvider(s)Test.java

### DIFF
--- a/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
+++ b/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
@@ -53,6 +53,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 import java.net.BindException;
 import java.rmi.AccessException;
 import java.rmi.RemoteException;
@@ -998,16 +999,25 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException ce) {
-      assertEquals(
-          InterruptedException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          Iterables.getOnlyElement(ce.getErrorMessages()).getMessage());
+        String actualMessage = Iterables.getOnlyElement(ce.getErrorMessages()).getMessage();
+        assertTrue(
+                (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage)
+                        ||
+                        (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage));
     }
   }
 
@@ -1024,16 +1034,25 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException ce) {
-      assertEquals(
-          InterruptedException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          Iterables.getOnlyElement(ce.getErrorMessages()).getMessage());
+        String actualMessage = Iterables.getOnlyElement(ce.getErrorMessages()).getMessage();
+        assertTrue(
+                (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage)
+                        ||
+                        (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage));
     }
   }
 
@@ -1127,16 +1146,25 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException ce) {
-      assertEquals(
-          IOException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          Iterables.getOnlyElement(ce.getErrorMessages()).getMessage());
+        String actualMessage = Iterables.getOnlyElement(ce.getErrorMessages()).getMessage();
+        assertTrue(
+                (IOException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage)
+                        ||
+                        (IOException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage));
     }
   }
 
@@ -1153,16 +1181,25 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException ce) {
-      assertEquals(
-          IOException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          Iterables.getOnlyElement(ce.getErrorMessages()).getMessage());
+        String actualMessage = Iterables.getOnlyElement(ce.getErrorMessages()).getMessage();
+        assertTrue(
+                (IOException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage)
+                        ||
+                        (IOException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(actualMessage));
     }
   }
 
@@ -1260,27 +1297,50 @@ public class CheckedProviderTest extends TestCase {
     } catch (CreationException ce) {
       // The only two that should fail are Interrupted & TooManyListeners.. the rest are OK.
       // Allow the msgs to come in any order.
-      ImmutableList<String> errors =
-          ce.getErrorMessages().stream().map(Message::getMessage).collect(toImmutableList());
-      String msg1 =
-          InterruptedException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")";
-      String msg2 =
-          TooManyListenersException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")";
-      assertThat(errors).containsExactly(msg1, msg2);
+        ImmutableList<String> errors =
+                ce.getErrorMessages().stream().map(Message::getMessage).collect(toImmutableList());
+        String msg1 =
+                InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")";
+        String msg2 =
+                TooManyListenersException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")";
+        String msg3 =
+                InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")";
+        String msg4 =
+                TooManyListenersException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")";
+        if(errors.contains(msg1) && errors.contains(msg2)) {
+            assertThat(errors).containsExactly(msg1, msg2);
+        }
+        else {
+            assertThat(errors).containsExactly(msg3, msg4);
+        }
     }
   }
 
@@ -1298,28 +1358,44 @@ public class CheckedProviderTest extends TestCase {
       fail();
     } catch (CreationException ce) {
       // The only two that should fail are Interrupted & TooManyListeners.. the rest are OK.
-      List<Message> errors = ImmutableList.copyOf(ce.getErrorMessages());
-      assertEquals(
-          InterruptedException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          errors.get(0).getMessage());
-      assertEquals(
-          TooManyListenersException.class.getName()
-              + " is not compatible with the exceptions (["
-              + RemoteException.class
-              + ", "
-              + BindException.class
-              + "]) declared in the CheckedProvider interface ("
-              + RemoteProvider.class.getName()
-              + ")",
-          errors.get(1).getMessage());
-      assertEquals(2, errors.size());
+        List<Message> errors = ImmutableList.copyOf(ce.getErrorMessages());
+        assertTrue(
+                (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(errors.get(0).getMessage())
+                        ||
+                        (InterruptedException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(errors.get(0).getMessage()));
+        assertTrue(
+                (TooManyListenersException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + RemoteException.class
+                        + ", "
+                        + BindException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(errors.get(1).getMessage())
+                        ||
+                        (TooManyListenersException.class.getName()
+                        + " is not compatible with the exceptions (["
+                        + BindException.class
+                        + ", "
+                        + RemoteException.class
+                        + "]) declared in the CheckedProvider interface ("
+                        + RemoteProvider.class.getName()
+                        + ")").equals(errors.get(1).getMessage()));
+        assertEquals(2, errors.size());
     }
   }
 
@@ -1427,12 +1503,18 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException ce) {
-      assertEquals(
-          ManyMethods.class.getName()
-              + " may not declare any new methods, but declared "
-              + Arrays.asList(ManyMethods.class.getDeclaredMethods()),
-          Iterables.getOnlyElement(ce.getErrorMessages()).getMessage());
-    }
+        Method[] declaredMethods =  ManyMethods.class.getDeclaredMethods();
+        String actualMessage = Iterables.getOnlyElement(ce.getErrorMessages()).getMessage();
+        assertTrue(String.format(
+                "%s may not declare any new methods, but declared %s",
+                ManyMethods.class.getName(),
+                Arrays.toString(new Method[] {declaredMethods[0], declaredMethods[1]})).equals(actualMessage)
+                ||
+                String.format(
+                "%s may not declare any new methods, but declared %s",
+                ManyMethods.class.getName(),
+                Arrays.toString(new Method[] {declaredMethods[1], declaredMethods[0]})).equals(actualMessage));
+}
   }
 
   public void testIncorrectPredefinedType_Bind() {

--- a/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProvidersTest.java
+++ b/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProvidersTest.java
@@ -4,6 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.inject.TypeLiteral;
+
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import junit.framework.TestCase;
 
@@ -77,18 +79,22 @@ public final class CheckedProvidersTest extends TestCase {
 
   public void testUnsupportedMethods_otherMethod_throwsIllegalArgumentException()
       throws NoSuchMethodException {
-    String message =
-        String.format(
+    Method[] declaredMethods =  MoreMethodsCheckedProvider.class.getDeclaredMethods();
+    String message1 = String.format(
             "%s may not declare any new methods, but declared %s",
             MoreMethodsCheckedProvider.class.getName(),
-            Arrays.toString(MoreMethodsCheckedProvider.class.getDeclaredMethods()));
+            Arrays.toString(new Method[] {declaredMethods[0], declaredMethods[1]}));
+    String message2 = String.format(
+            "%s may not declare any new methods, but declared %s",
+            MoreMethodsCheckedProvider.class.getName(),
+            Arrays.toString(new Method[] {declaredMethods[1], declaredMethods[0]}));
 
     try {
       CheckedProviders.of(
           new TypeLiteral<MoreMethodsCheckedProvider<String>>() {}, "SHOW ME WHAT YOU GOT");
       fail("Expected an exception to be thrown");
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo(message);
+        assertThat(e).hasMessageThat().isAnyOf(message1, message2);
     }
   }
 


### PR DESCRIPTION
This PR fixes 8 possible test failures in the module extensions/throwingproviders

1. Test that could fail

Module: extensions/throwingproviders

Class Name1: com.google.inject.throwingproviders.CheckedProvidersTest, 
Test Name: [testUnsupportedMethods_otherMethod_throwsIllegalArgumentException](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProvidersTest.java#L78)

Class Name2: testUnsupportedMethods_otherMethod_throwsIllegalArgumentException
Test Names: [testCxtorWithManyExceptions](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1299), [testCxtorWithSuperclassExceptionFails](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1156), [testCxtorWithWrongException](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1027), [testManyMethods](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1429), [testProviderMethodWithManyExceptions](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1260), [testProviderMethodWithSuperclassExceptionFails](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1129), [testProviderMethodWithWrongException](https://github.com/harshith2000/guice/blob/ba3553a6974bdab9e3e860b525c101fe43111823/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java#L1001)


2. Why the tests might fail?

The test - testUnsupportedMethods_otherMethod_throwsIllegalArgumentException in CheckedProvidersTest.java has the getDeclaredMethods(). 
According to the official [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--), this returns the methods in a different order each time it is called, making this test flaky i.e. non-deterministic. 

The tests testCxtorWithManyExceptions, testCxtorWithSuperclassExceptionFails, testCxtorWithWrongException, testManyMethods, testProviderMethodWithManyExceptions, testProviderMethodWithSuperclassExceptionFails, testProviderMethodWithWrongException in CheckedProviderTest.java has the getErrorMessages(). 
This returns the error messages in a different order each time it is called. For instance, sometimes it returns [RemoteException, BindException], but at other times, it returns [BindException, RemoteException]. 

Since there is no guarantee in the order of exception types returned, the order might change, resulting in the test failure.

3. How to reproduce?

I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation

 Clone the Repo
```
https://github.com/google/guice
```
 Compile the module byte-buddy-dep
```
mvn clean install extensions/throwingproviders -am -DskipTests
```
 (Optional) Run the unit test
```
mvn -pl throwingproviders test -Dtest=com.google.inject.throwingproviders.CheckedProvidersTest#testUnsupportedMethods_otherMethod_throwsIllegalArgumentException
```
 Run the unit test using NonDex
```
mvn -pl throwingproviders edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.inject.throwingproviders.CheckedProvidersTest#testUnsupportedMethods_otherMethod_throwsIllegalArgumentException
```
4. How I fixed?

Since the order of the methods or error messages is not guaranteed, it is important to consider all possible orders. Fortunately, only two possible orders are possible for both methods and error messages. By checking if the actual message is equal to any of the orders, we can fix the flakiness. 